### PR TITLE
Make bspwmrc executable and fix his reloading

### DIFF
--- a/src/bin/ravenlib/mod.rs
+++ b/src/bin/ravenlib/mod.rs
@@ -2,6 +2,7 @@
 pub mod rlib {
     use std::fs;
     use std::fs::{OpenOptions, DirEntry};
+    use std::os::unix::fs::OpenOptionsExt;
     use std::io::Read;
     use std::env;
     use std::io::Write;
@@ -209,13 +210,18 @@ pub mod rlib {
             OpenOptions::new()
                 .create(true)
                 .write(true)
+                .mode(0o744)
                 .open(get_home() + "/.config/bspwm/bspwmrc")
                 .expect("Couldn't open bspwmrc file")
                 .write_all(config.as_bytes())
                 .unwrap();
-            Command::new("bspc").arg("reload").output().expect(
-                "Couldn't reload bspwm",
-            );
+            Command::new("sh")
+                .arg("-c")
+                .arg(
+                    get_home() + "/.config/bspwm/bspwmrc",
+                )
+                .output()
+                .expect("Couldn't reload bspwm");
         }
         pub fn load_i3(&self, isw: bool) {
             let mut config = String::new();


### PR DESCRIPTION
bspc reload was deprecated on [2013](https://github.com/baskerville/bspwm/commit/f7e38e44a7936b4d13d4154ade9bc7a768c2ea2d)
Instead, you just need to execute it. (is a script.)