### PR TITLE
Add VSCode support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The following packages are required for their relevant options:
 
 + [Sublime Text 3](https://www.sublimetext.com/) : `st_tmtheme`, `st_scs` and `st_subltheme`
 
++ [VSCode](https://github.com/Microsoft/vscode) : `vscode`
+
 * New option suggestions are very welcome!
 
 You can also download a prebuilt binary from [here](https://github.com/nicohman/raven/releases)
@@ -119,6 +121,7 @@ To configure a theme, start off by creating it with `raven new [theme]`. You'll 
 + [st_tmtheme](#sublime-text-3)
 + [st_scs](#sublime-text-3)
 + [st_subltheme](#sublime-text-3)
++ vscode (Plain text containing the name of an already installed VSCode theme.)
 
 base_ files allow splitting the config from the cosmetics on the options with [base_]
 For example if you place an i3 config named base\_i3 in ~/.config/raven, the contents of i3 for a theme will be appended to it instead of being run on their own. This allows you to have a central config for keyboard shortcuts, and have cosmetics only be stored in the theme.

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -53,6 +53,7 @@ impl Theme {
                 "st_tmtheme" => self.load_sublt("st_tmtheme"),
                 "st_scs" => self.load_sublt("st_scs"),
                 "st_subltheme" => self.load_sublt("st_subltheme"),
+                "vscode" => self.load_vscode(),
                 "|" => {}
                 _ => println!("Unknown option"),
             };
@@ -62,6 +63,59 @@ impl Theme {
             i += 1;
         }
         println!("Loaded all options for theme {}", self.name);
+    }
+    /// Edits the value of a key in hjson files
+    fn edit_hjson<N>(&self, file: N, pat: &str, value: &str)
+    where
+        N: Into<String>,
+    {
+        let file = &file.into();
+        let mut finals = String::new();
+        if fs::metadata(file).is_ok() {
+            let mut pre = String::new();
+            fs::File::open(file)
+                .expect("Couldn't open hjson file")
+                .read_to_string(&mut pre)
+                .unwrap();
+            let mut patfound = false;
+            for line in pre.lines() {
+                if line.contains(pat) {
+                    patfound = true;
+                    if line.ends_with(",") {
+                        finals = finals + "\n" + "    " + pat + "\"" + &value + "\","
+                    } else {
+                        finals = finals + "\n" + "    " + pat + "\"" + &value + "\""
+                    }
+                } else if line.ends_with("}") && !patfound {
+                    finals =
+                        finals + "," + "\n" + "    " + pat + "\"" + &value + "\"" + "\n" + line;
+                } else {
+                    finals = finals + "\n" + line;
+                }
+            }
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(file)
+                .expect("Couldn't open hjson file")
+                .write_all(finals.trim().as_bytes())
+                .unwrap();
+        } else {
+            finals = finals
+                + "{\n    "
+                + pat
+                + "\""
+                + &value
+                + "\"\n}";
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(file)
+                .expect("Couldn't open hjson file")
+                .write_all(finals.as_bytes())
+                .unwrap();
+        }
     }
     pub fn load_rofi(&self) {
         if fs::metadata(get_home() + "/.config/rofi").is_err() {
@@ -149,18 +203,40 @@ impl Theme {
             .unwrap();
         Command::new("dunst").spawn().expect("Failed to run dunst");
     }
-
+    pub fn load_vscode(&self) {
+        let path1 = get_home() + "/.config/Code/User";
+        let path2 = get_home() + "/.config/Code - OSS/User";
+        if fs::metadata(&path1).is_err() && fs::metadata(&path2).is_err() {
+            println!(
+                "Couldn't find neither .config/Code nor .config/Code - OSS. Do you have VSCode installed? \
+                Skipping."
+            );
+            return;
+        }
+        let pattern = "\"workbench.colorTheme\": ";
+        let mut value = String::new();
+        fs::File::open(get_home() + "/.config/raven/themes/" + &self.name + "/vscode")
+            .unwrap()
+            .read_to_string(&mut value)
+            .unwrap();
+        if fs::metadata(&path1).is_ok() {
+            self.edit_hjson(path1 + "/settings.json", pattern, &value)
+        }
+        if fs::metadata(&path2).is_ok() {
+            self.edit_hjson(path2 + "/settings.json", pattern, &value)
+        }
+    }
     pub fn load_sublt<N>(&self, stype: N)
     where
         N: Into<String>,
     {
         let stype = &stype.into();
-        let sublpath = "/.config/sublime-text-3/Packages/User";
-        if fs::metadata(get_home() + &sublpath).is_err() {
+        let path = get_home() + "/.config/sublime-text-3/Packages/User";
+        if fs::metadata(&path).is_err() {
             println!(
                 "Couldn't find {}. Do you have sublime text 3 installed? \
                  Skipping.",
-                get_home() + &sublpath
+                &path
             );
             return;
         }
@@ -170,62 +246,13 @@ impl Theme {
             .unwrap()
             .read_to_string(&mut value)
             .unwrap();
-        let mut pat = "";
+        let mut pattern = "";
         if stype == "st_tmtheme" || stype == "st_scs" {
-            pat = "\"color_scheme\": ";
+            pattern = "\"color_scheme\": ";
         } else if stype == "st_subltheme" {
-            pat = "\"theme\": ";
+            pattern = "\"theme\": ";
         }
-        if fs::metadata(get_home() + sublpath + "/Preferences.sublime-settings").is_ok() {
-            let mut pre = String::new();
-            fs::File::open(get_home() + sublpath + "/Preferences.sublime-settings")
-                .expect("Couldn't open sublime settings")
-                .read_to_string(&mut pre)
-                .unwrap();
-            let mut finals = String::new();
-            let mut patfound = false;
-            for line in pre.lines() {
-                if line.contains(pat) {
-                    patfound = true;
-                    if line.ends_with(",") {
-                        finals = finals + "\n" + "    " + pat + "\"" + &value + "\","
-                    } else {
-                        finals = finals + "\n" + "    " + pat + "\"" + &value + "\""
-                    }
-                } else if line.ends_with("}") && !patfound {
-                    finals =
-                        finals + "," + "\n" + "    " + pat + "\"" + &value + "\"" + "\n" + line;
-                } else {
-                    finals = finals + "\n" + line;
-                }
-            }
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(get_home() + sublpath + "/Preferences.sublime-settings")
-                .expect("Couldn't open sublime settings")
-                .write_all(finals.trim().as_bytes())
-                .unwrap();
-        } else {
-            let mut finals = String::new();
-            finals = finals
-                + "// Settings in here override those in \
-                   \"Default/Preferences.sublime-settings\",\n\
-                   // and are overridden in turn by syntax-specific settings.\n\
-                   {\n    "
-                + pat
-                + "\""
-                + &value
-                + "\"\n}";
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .open(get_home() + sublpath + "/Preferences.sublime-settings")
-                .expect("Couldn't open sublime settings")
-                .write_all(finals.as_bytes())
-                .unwrap();
-        }
+        self.edit_hjson(path + "/Preferences.sublime-settings", &pattern, &value)
     }
 
     pub fn load_ncm(&self) {

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -65,11 +65,15 @@ impl Theme {
         println!("Loaded all options for theme {}", self.name);
     }
     /// Edits the value of a key in hjson files
-    fn edit_hjson<N>(&self, file: N, pat: &str, value: &str)
+    fn edit_hjson<N,S,T>(&self, file: N, pat: S, value: T)
     where
         N: Into<String>,
+        S: Into<String>,
+        T: Into<String>,
     {
         let file = &file.into();
+        let pat = &pat.into();
+        let value = &value.into();
         let mut finals = String::new();
         if fs::metadata(file).is_ok() {
             let mut pre = String::new();
@@ -220,10 +224,10 @@ impl Theme {
             .read_to_string(&mut value)
             .unwrap();
         if fs::metadata(&path1).is_ok() {
-            self.edit_hjson(path1 + "/settings.json", pattern, &value)
+            self.edit_hjson(path1 + "/settings.json", pattern, value.as_str())
         }
         if fs::metadata(&path2).is_ok() {
-            self.edit_hjson(path2 + "/settings.json", pattern, &value)
+            self.edit_hjson(path2 + "/settings.json", pattern, value)
         }
     }
     pub fn load_sublt<N>(&self, stype: N)
@@ -252,7 +256,7 @@ impl Theme {
         } else if stype == "st_subltheme" {
             pattern = "\"theme\": ";
         }
-        self.edit_hjson(path + "/Preferences.sublime-settings", &pattern, &value)
+        self.edit_hjson(path + "/Preferences.sublime-settings", pattern, value)
     }
 
     pub fn load_ncm(&self) {


### PR DESCRIPTION
At least on arch based distros, VSCode can be installed as code and as code-oss so unless we let the user specify which one to theme I think the best way is to theme both in case they exist.

But then I need to recover the ownership of pattern and value when using them on edit_hjson() from load_vscode()
Should I borrow, clone, move them and then returning a tuple or something else?