### PR TITLE
Allow copying sublt themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,4 +138,6 @@ With the cycle command you can control a daemon that will automatically cycle th
 
 ### Sublime Text 3
 
-Plain text containing the absolute (allowing `$HOME` and `~`) or relative path (To the sublime config directory. Usually `~/.config/sublime-text-3/`) of a .tmTheme, .sublime-color-scheme or .sublime-theme file.
+Plain text containing `sublt/<filename>.<extension>` (which you must create on your theme folder) or the name of an already installed theme (e.g `DA.sublime-theme`)
+
+Extensions: st_tmtheme (`.tmTheme`), st_scs (`.sublime-color-scheme`) and st_subltheme (`.sublime-theme`)

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -43,7 +43,7 @@ impl Theme {
     {
         let (k, v) = (k.into(), v.into());
         match k.as_str() {
-            "sm_tmtheme" => self.load_sublt("st_tmtheme", v.as_str()),
+            "st_tmtheme" => self.load_sublt("st_tmtheme", v.as_str()),
             "st_scs" => self.load_sublt("st_scs", v.as_str()),
             "st_subltheme" => self.load_sublt("st_subltheme", v.as_str()),
             "vscode" => self.load_vscode(v.as_str()),
@@ -283,7 +283,16 @@ impl Theme {
             return;
         }
 
-        let value = value.into();
+        let mut value = value.into();
+        if value.starts_with("sublt/") {
+            value = value.trim_start_matches("sublt/").to_string();
+            fs::copy(
+                get_home() + "/.config/raven/themes/" + &self.name + "/sublt/" + &value,
+                path.clone() + "/" + &value
+            )
+            .expect("Couldn't overwrite sublt theme");
+        }
+
         let mut pattern = "";
         if stype == "st_tmtheme" || stype == "st_scs" {
             pattern = "\"color_scheme\": ";


### PR DESCRIPTION
I tried to avoid this but sublime fooled me, it ignores completely the given path and instead searches for the theme name inside his folders. So unless the user installs the theme manually is necessary to copy it.
It's still possible to choose an installed theme and avoid the copy though.

PD: I guess line 46 was a typo so I changed it.